### PR TITLE
Add more-itertools to requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Poro also check if a tag you specify is applied to identified public resources u
 - boto3>=1.20
 - botocore>= 1.20
 - enlighten>=1
+- more-itertools >= 8.13
 
 ## Usage
 - Clone this repository

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ enlighten>=1
 requests>=2.22.0
 boto3>=1.20
 botocore>= 1.20
+more-itertools==8.13.0


### PR DESCRIPTION
@9rnt thank you for the awesome package!

I was getting this error when trying to run poro:

```
Traceback (most recent call last):
  File "poro.py", line 3, in <module>
    from more_itertools import bucket
ModuleNotFoundError: No module named 'more_itertools'
```